### PR TITLE
prevent AV in component editor

### DIFF
--- a/source/FrameStand.Editors.Forms.Test.fmx
+++ b/source/FrameStand.Editors.Forms.Test.fmx
@@ -9,6 +9,7 @@ object TestForm: TTestForm
   FormFactor.Height = 480
   FormFactor.Devices = [Desktop]
   OnCreate = FormCreate
+  OnDestroy = FormDestroy
   DesignerMasterStyle = 0
   object TopLayout: TLayout
     Align = Top

--- a/source/FrameStand.Editors.Forms.Test.pas
+++ b/source/FrameStand.Editors.Forms.Test.pas
@@ -38,6 +38,7 @@ type
     procedure HideActionUpdate(Sender: TObject);
     procedure ShowActionUpdate(Sender: TObject);
     procedure FormCreate(Sender: TObject);
+    procedure FormDestroy(Sender: TObject);
   private
     FFrameStand: TFrameStand;
     FFrameInfo: TFrameInfo<TTestFrame>;
@@ -53,7 +54,6 @@ type
     property SelectedStyleName: string read GetSelectedStyleName;
     property SelectedFrameAlign: TAlignLayout read GetSelectedFrameAlign;
   public
-
     property FrameStand: TFrameStand read FFrameStand write SetFrameStand;
     property StyleBook: TStyleBook read GetStyleBook;
   end;
@@ -85,12 +85,17 @@ begin
         StandComboBox.ItemIndex := 0;
     end;
   end;
-
 end;
 
 procedure TTestForm.FormCreate(Sender: TObject);
 begin
   Init;
+end;
+
+procedure TTestForm.FormDestroy(Sender: TObject);
+begin
+  if Assigned(FFrameInfo) then
+    FFrameInfo.Close;
 end;
 
 function TTestForm.GetSelectedFrameAlign: TAlignLayout;

--- a/source/FrameStand.Editors.pas
+++ b/source/FrameStand.Editors.pas
@@ -47,7 +47,7 @@ begin
     LForm.FrameStand := CurrentObj;
     LForm.ShowModal;
   finally
-    FreeAndNil(LForm);
+    LForm.Release;
   end;
 end;
 


### PR DESCRIPTION
when user doesn't hide form after a show action, when user exits Delphi IDE an exception is raised, because of not closing frameinfo instance in test form